### PR TITLE
Fix badge URL for Unit Tests in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A sophisticated `C++` simulation of a plant nursery management system, developed
 ![GitHub Issues](https://img.shields.io/github/issues/u24569608/COS_214-Final_Project)
 ![GitHub Pull Requests](https://img.shields.io/github/issues-pr/u24569608/COS_214-Final_Project)
 ![GitHub Repo Size](https://img.shields.io/github/repo-size/u24569608/COS_214-Final_Project)
-![Unit Tests](https://github.com/u24569608/COS_214-Final_Project/actions/workflows/unit-tests.yml/badge.svg?branch=developer)
+![Unit Tests](https://github.com/u24569608/COS_214-Final_Project/actions/workflows/unit_tests.yml/badge.svg?branch=developer)
 
 ## Key Features
 


### PR DESCRIPTION
Title: Update the Unit Tests Badge 

## Summary
This pull request updates the badge link for unit test workflow in the `README.md` file to ensure it correctly reflects the status of unit tests. The change improves the accuracy and visibility of CI status on the project page.

* Documentation update:
  * [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L13-R13): Corrected the unit test badge link to reference the updated workflow file name (`unit_tests.yml` instead of `unit-tests.yml`).

## Related Issues
Closes #<issue-number>

## Type of Change
- [ ] feat (new feature)
- [x] fix (bug fix)
- [x] docs (documentation)
- [ ] chore (maintenance)

## How To Test
N/A

## Screenshots/Logs
N/A

## Checklist
- [x] Targets `development`
- [x] Builds and tests pass locally
- [x] Small and focused (one logical change)
- [x] Docs updated (if needed)
- [x] Requested at least one reviewer (we recommend two)

