### PR TITLE
Update clone methods to return pointer and be const

### DIFF
--- a/plant-nursery-simulator/include/FertilizeStrategy.h
+++ b/plant-nursery-simulator/include/FertilizeStrategy.h
@@ -14,7 +14,7 @@ public:
      * @brief Abstract method to execute the fertilizing strategy.
      */
     virtual void fertilize(PlantInstance& plant) const = 0;
-    virtual void clone() = 0 ;
+    virtual FertilizeStrategy* clone() const = 0;
 
 };
 

--- a/plant-nursery-simulator/include/FrequentWatering.h
+++ b/plant-nursery-simulator/include/FrequentWatering.h
@@ -11,7 +11,7 @@ class FrequentWatering : public WaterStrategy {
 public:
     FrequentWatering();
     void water(PlantInstance& plant) const override;
-    void clone();
+   WaterStrategy* clone() const override;
 };
 
 #endif // FREQUENT_WATERING_H

--- a/plant-nursery-simulator/include/LiquidFertilizer.h
+++ b/plant-nursery-simulator/include/LiquidFertilizer.h
@@ -11,7 +11,8 @@ class LiquidFertilizer : public FertilizeStrategy {
 public:
     LiquidFertilizer();
     void fertilize(PlantInstance& plant) const override;
-    void clone();
+    FertilizeStrategy* clone() const override;
+
 };
 
 #endif // LIQUID_FERTILIZER_H

--- a/plant-nursery-simulator/include/OrganicFertilizer.h
+++ b/plant-nursery-simulator/include/OrganicFertilizer.h
@@ -11,7 +11,8 @@ class OrganicFertilizer : public FertilizeStrategy {
 public:
     OrganicFertilizer();
     void fertilize(PlantInstance& plant) const override;
-    void clone();
+    FertilizeStrategy* clone() const override;
+
 };
 
 #endif // ORGANIC_FERTILIZER_H

--- a/plant-nursery-simulator/include/SeasonalWatering.h
+++ b/plant-nursery-simulator/include/SeasonalWatering.h
@@ -11,7 +11,7 @@ class SeasonalWatering : public WaterStrategy {
 public:
     SeasonalWatering();
     void water(PlantInstance& plant) const override;
-    void clone();
+    WaterStrategy* clone() const override;
 };
 
 #endif // SEASONAL_WATERING_H

--- a/plant-nursery-simulator/include/SlowReleaseFertilizer.h
+++ b/plant-nursery-simulator/include/SlowReleaseFertilizer.h
@@ -11,7 +11,8 @@ class SlowReleaseFertilizer : public FertilizeStrategy {
 public:
     SlowReleaseFertilizer();
     void fertilize(PlantInstance& plant) const override;
-    void clone();
+    FertilizeStrategy* clone() const override;
+
 };
 
 #endif // SLOW_RELEASE_FERTILIZER_H

--- a/plant-nursery-simulator/include/SparseWatering.h
+++ b/plant-nursery-simulator/include/SparseWatering.h
@@ -11,7 +11,7 @@ class SparseWatering : public WaterStrategy {
 public:
     SparseWatering();
     void water(PlantInstance& plant) const override;
-    void clone();
+    WaterStrategy* clone() const override;
     
 };
 

--- a/plant-nursery-simulator/include/WaterStrategy.h
+++ b/plant-nursery-simulator/include/WaterStrategy.h
@@ -14,8 +14,7 @@ public:
      * @brief Abstract method to execute the watering strategy.
      */
     virtual void water(PlantInstance& plant) const = 0;
-    virtual void clone() = 0;
-    
+  virtual WaterStrategy* clone() const = 0;    
 };
 
 #endif // WATER_STRATEGY_H


### PR DESCRIPTION
Changed the clone() methods in FertilizeStrategy, WaterStrategy, and their derived classes to return a pointer to the respective type and marked them as const. This ensures proper polymorphic cloning and aligns with best practices for implementing the prototype pattern.

Title: <type(scope): short description>

## Summary
What does this PR change and why?

## Related Issues
Closes #<issue-number>

## Type of Change
- [ ] feat (new feature)
- [x] fix (bug fix)
- [ ] docs (documentation)
- [ ] chore (maintenance)

## How To Test
If applicable, describe the steps to test the changes made in this PR.

## Screenshots/Logs
If applicable, add screenshots or logs to help explain the changes made in this PR.

## Checklist
- [ ] Targets `development`
- [ ] Builds and tests pass locally
- [ ] Small and focused (one logical change)
- [ ] Docs updated (if needed)
- [ ] Requested at least one reviewer (we recommend two)

