### PR TITLE
feat(plant-prototype): Plant Prototype and Registry implemented

### DIFF
--- a/plant-nursery-simulator/Makefile
+++ b/plant-nursery-simulator/Makefile
@@ -1,4 +1,4 @@
-test: iterator_unit_test mediator_unit_test command_unit_test builder_unit_test chain_of_responsibility_unit_test facade_unit_test adapter_unit_test greenhouse_iterator_unit_test plant_instance_unit_test composite_unit_test
+test: iterator_unit_test mediator_unit_test command_unit_test builder_unit_test chain_of_responsibility_unit_test facade_unit_test adapter_unit_test greenhouse_iterator_unit_test plant_instance_unit_test composite_unit_test prototype_unit_test
 	@echo "==== ALL PROJECT TESTS DONE ===="
 
 clean:
@@ -168,8 +168,18 @@ composite_unit_test:
 		src/GreenhouseController.cpp \
 		src/PlantInstance.cpp \
 		src/Plant.cpp \
-		-o build/composite_unit_test
+	-o build/composite_unit_test
 	./build/composite_unit_test
+
+prototype_unit_test:
+	@echo "== Building and Running 'prototype_test.cpp' (UNIT TEST) =="
+	@mkdir -p build
+	g++ -std=c++17 -Wall -Wextra -pedantic -Iinclude \
+		tests/prototype_test.cpp \
+		src/Plant.cpp \
+		src/PlantPrototypeRegistry.cpp \
+		-o build/prototype_unit_test
+	./build/prototype_unit_test
 
 greenhouse_iterator_unit_test:
 	@echo "== Building and Running 'greenhouse_iterator_test.cpp' (UNIT TEST) =="

--- a/plant-nursery-simulator/include/Plant.h
+++ b/plant-nursery-simulator/include/Plant.h
@@ -12,28 +12,56 @@
  */
 class Plant {
 public:
+    /**
+     * @brief Constructs an empty prototype with no default strategies configured.
+     */
+    Plant();
     virtual ~Plant();
 
     /**
      * @brief Creates a deep copy of this plant prototype.
      * @return Plant* A pointer to the newly cloned plant.
      */
-     Plant* clone() const ;
+    virtual Plant* clone() const = 0;
 
-     std::string getName() const ;
-     std::string getType() const ;
+    std::string getName() const;
+    std::string getType() const;
+
+    /**
+     * @brief Assigns a human-readable display name to the prototype.
+     * @param newName The name to set.
+     */
+    void setName(const std::string& newName);
+
+    /**
+     * @brief Updates the categorical type for the prototype (e.g. Succulent, Herb).
+     * @param newType The type string to assign.
+     */
+    void setType(const std::string& newType);
 
     /**
      * @brief Creative Function: Gets the ideal water strategy for this plant.
      * @return WaterStrategy*.
      */
-     WaterStrategy* getDefaultWaterStrat() const;
+    WaterStrategy* getDefaultWaterStrat() const;
 
     /**
      * @brief Creative Function: Gets the ideal fertilizer strategy.
      * @return FertilizeStrategy*.
      */
-     FertilizeStrategy* getDefaultFertStrat() const;
+    FertilizeStrategy* getDefaultFertStrat() const;
+
+    /**
+     * @brief Sets the default watering strategy associated with this prototype.
+     * @param strategy Pointer to a WaterStrategy instance (non-owning).
+     */
+    void setDefaultWaterStrat(WaterStrategy* strategy);
+
+    /**
+     * @brief Sets the default fertilizing strategy associated with this prototype.
+     * @param strategy Pointer to a FertilizeStrategy instance (non-owning).
+     */
+    void setDefaultFertStrat(FertilizeStrategy* strategy);
 
 protected:
     std::string name;

--- a/plant-nursery-simulator/include/PlantPrototypeRegistry.h
+++ b/plant-nursery-simulator/include/PlantPrototypeRegistry.h
@@ -20,17 +20,17 @@ public:
     /**
      * @brief Adds a plant prototype to the registry.
      * @param name The key to store the prototype under.
-     * @param plant A pointer to the prototype.
+     * @param plant A unique_ptr owning the prototype instance.
      */
-    void addPrototype(std::string name, Plant* plant);
+    void addPrototype(const std::string& name, std::unique_ptr<Plant> plant);
 
     /**
      * @brief Clones a plant from the registry.
      * @param name The key of the prototype to clone. 
-     * @param type the type of plant to clone.
+     * @param type Optional override for the clone's type classification.
      * @return Plant* A new clone, or nullptr if not found.
      */
-    Plant* createPlant(std::string name, std::string type);
+    Plant* createPlant(const std::string& name, const std::string& type);
 
 private:
     std::map<std::string, std::unique_ptr<Plant>> prototypes;

--- a/plant-nursery-simulator/src/Plant.cpp
+++ b/plant-nursery-simulator/src/Plant.cpp
@@ -1,11 +1,8 @@
 #include "../include/Plant.h"
 
-Plant::~Plant() = default;
+Plant::Plant() : defaultWaterStrat(nullptr), defaultFertilizerStrat(nullptr) {}
 
-Plant* Plant::clone() const {
-    // TODO(FR3): Provide deep copy logic when prototype catalogue is implemented.
-    return nullptr;
-}
+Plant::~Plant() = default;
 
 std::string Plant::getName() const {
     return name;
@@ -13,6 +10,14 @@ std::string Plant::getName() const {
 
 std::string Plant::getType() const {
     return type;
+}
+
+void Plant::setName(const std::string& newName) {
+    name = newName;
+}
+
+void Plant::setType(const std::string& newType) {
+    type = newType;
 }
 
 WaterStrategy* Plant::getDefaultWaterStrat() const {
@@ -23,3 +28,10 @@ FertilizeStrategy* Plant::getDefaultFertStrat() const {
     return defaultFertilizerStrat;
 }
 
+void Plant::setDefaultWaterStrat(WaterStrategy* strategy) {
+    defaultWaterStrat = strategy;
+}
+
+void Plant::setDefaultFertStrat(FertilizeStrategy* strategy) {
+    defaultFertilizerStrat = strategy;
+}

--- a/plant-nursery-simulator/src/PlantPrototypeRegistry.cpp
+++ b/plant-nursery-simulator/src/PlantPrototypeRegistry.cpp
@@ -1,0 +1,34 @@
+#include "../include/PlantPrototypeRegistry.h"
+#include "../include/Plant.h"
+
+#include <utility>
+
+PlantPrototypeRegistry::PlantPrototypeRegistry() = default;
+
+PlantPrototypeRegistry::~PlantPrototypeRegistry() = default;
+
+void PlantPrototypeRegistry::addPrototype(const std::string& name, std::unique_ptr<Plant> plant) {
+    if (name.empty() || !plant) {
+        return;
+    }
+
+    prototypes[name] = std::move(plant);
+}
+
+Plant* PlantPrototypeRegistry::createPlant(const std::string& name, const std::string& type) {
+    auto it = prototypes.find(name);
+    if (it == prototypes.end() || it->second == nullptr) {
+        return nullptr;
+    }
+
+    Plant* clone = it->second->clone();
+    if (clone == nullptr) {
+        return nullptr;
+    }
+
+    if (!type.empty()) {
+        clone->setType(type);
+    }
+
+    return clone;
+}

--- a/plant-nursery-simulator/tests/plant_instance_test.cpp
+++ b/plant-nursery-simulator/tests/plant_instance_test.cpp
@@ -11,6 +11,10 @@ public:
     explicit DummyPlant(const std::string& label) {
         name = label;
     }
+
+    Plant* clone() const override {
+        return new DummyPlant(*this);
+    }
 };
 
 int failures = 0;

--- a/plant-nursery-simulator/tests/prototype_test.cpp
+++ b/plant-nursery-simulator/tests/prototype_test.cpp
@@ -1,0 +1,130 @@
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include "../include/Plant.h"
+#include "../include/PlantPrototypeRegistry.h"
+
+namespace {
+
+class StubPlant : public Plant {
+public:
+    StubPlant(const std::string& nameValue, const std::string& typeValue) {
+        setName(nameValue);
+        setType(typeValue);
+    }
+
+    StubPlant(const StubPlant&) = default;
+
+    Plant* clone() const override {
+        return new StubPlant(*this);
+    }
+};
+
+int failures = 0;
+
+void assertTrue(bool expression, const std::string& message) {
+    if (!expression) {
+        std::cerr << "[ASSERT_TRUE FAILED] " << message << std::endl;
+        ++failures;
+    }
+}
+
+void assertEqStr(const std::string& actual, const std::string& expected, const std::string& message) {
+    if (actual == expected) {
+        return;
+    }
+
+    std::cerr << "[ASSERT_EQ_STR FAILED] " << message
+              << " (expected \"" << expected << "\", got \"" << actual << "\")" << std::endl;
+    ++failures;
+}
+
+void assertPtrNotSame(const void* lhs, const void* rhs, const std::string& message) {
+    if (lhs != rhs) {
+        return;
+    }
+
+    std::cerr << "[ASSERT_PTR_NOT_SAME FAILED] " << message << std::endl;
+    ++failures;
+}
+
+} // namespace
+
+void testBaseCloneProducesDistinctInstance() {
+    std::cout << "Running test: testBaseCloneProducesDistinctInstance..." << std::endl;
+
+    StubPlant prototype("Prototype Basil", "Herb");
+    Plant* clone = prototype.clone();
+
+    assertTrue(clone != nullptr, "clone() should produce a valid object");
+    if (clone != nullptr) {
+        assertPtrNotSame(clone, &prototype, "clone() should not return the same pointer");
+        assertEqStr(clone->getName(), "Prototype Basil", "clone() should copy the prototype name");
+        assertEqStr(clone->getType(), "Herb", "clone() should copy the prototype type");
+        delete clone;
+    }
+}
+
+void testRegistryCreatesPlantFromPrototype() {
+    std::cout << "Running test: testRegistryCreatesPlantFromPrototype..." << std::endl;
+
+    PlantPrototypeRegistry registry;
+    auto prototype = std::make_unique<StubPlant>("Registry Rose", "Flower");
+    const Plant* original = prototype.get();
+    registry.addPrototype("rose", std::move(prototype));
+
+    Plant* clone = registry.createPlant("rose", "");
+    assertTrue(clone != nullptr, "createPlant() should return a clone when the key exists");
+    if (clone != nullptr) {
+        assertPtrNotSame(clone, original, "createPlant() should return a new instance");
+        assertEqStr(clone->getName(), "Registry Rose", "Cloned plant should copy the prototype name");
+        assertEqStr(clone->getType(), "Flower", "Cloned plant should preserve the prototype type when no override is supplied");
+        delete clone;
+    }
+}
+
+void testRegistryAppliesTypeOverride() {
+    std::cout << "Running test: testRegistryAppliesTypeOverride..." << std::endl;
+
+    PlantPrototypeRegistry registry;
+    auto prototype = std::make_unique<StubPlant>("Lavender", "Herb");
+    registry.addPrototype("lavender", std::move(prototype));
+
+    Plant* overridden = registry.createPlant("lavender", "Medicinal");
+    assertTrue(overridden != nullptr, "createPlant() should succeed for registered keys");
+    if (overridden != nullptr) {
+        assertEqStr(overridden->getType(), "Medicinal", "createPlant() should apply the provided type override");
+        delete overridden;
+    }
+
+    Plant* missing = registry.createPlant("unknown", "");
+    assertTrue(missing == nullptr, "createPlant() should return nullptr for an unknown key");
+}
+
+int main() {
+    int testsPassed = 0;
+    int baseline = failures;
+
+    testBaseCloneProducesDistinctInstance();
+    if (failures == baseline) { ++testsPassed; }
+    baseline = failures;
+
+    testRegistryCreatesPlantFromPrototype();
+    if (failures == baseline) { ++testsPassed; }
+    baseline = failures;
+
+    testRegistryAppliesTypeOverride();
+    if (failures == baseline) { ++testsPassed; }
+
+    std::cout << "\n---------------------------\n";
+    std::cout << "     TEST SUMMARY          \n";
+    std::cout << " Tests Passed: " << testsPassed << " / 3" << std::endl;
+    std::cout << "---------------------------\n";
+
+    if (failures == 0) {
+        return 0;
+    }
+    std::cerr << "[FAIL] " << failures << " test(s) failed." << std::endl;
+    return 1;
+}


### PR DESCRIPTION
This pull request introduces the prototype (clone) implementation for plant objects, including a registry for managing and cloning plant prototypes. It adds support for deep copying plant instances, allows overriding type information during cloning, and provides thorough unit tests to verify the new functionality. The changes also improve the `Plant` interface for better configurability and memory safety.

### Prototype Pattern Implementation:

* Added a new `PlantPrototypeRegistry` class with methods to register and clone plant prototypes using deep copies, leveraging `std::unique_ptr` for ownership and memory safety.
* Updated the `Plant` base class to require a pure virtual `clone()` method, and added setter methods for name, type, and default strategies to support prototype configuration.

### Unit Testing and Build Integration:

* Added a new unit test file `prototype_test.cpp` that verifies cloning behavior, registry operations, and type overrides for plant prototypes. (`plant-nursery-simulator/tests/prototype_test.cpp`)
* Integrated the new prototype unit test into the build system by updating the `Makefile` to build and run `prototype_test.cpp`. (`plant-nursery-simulator/Makefile`)

### Related Issues
Closes #11 

### Type of Change
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] chore (maintenance)

### How To Test
```
make prototype_unit_test,
make plant_instance_unit_test
```

### Checklist
- [x] Targets `development`
- [x] Builds and tests pass locally
- [x] Small and focused (one logical change)
- [ ] Docs updated (if needed)
- [x] Requested at least one reviewer (we recommend two)

